### PR TITLE
feat: flashlight

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/local/Cellar/python@3.9/3.9.1_3/Frameworks/Python.framework/Versions/3.9/bin/python3.9"
-}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ aims to provide a similar experience of high configurability with ease of use.
 - Reacting to printer states including:
   - Idle
   - Disconnected
-  - Print started
   - Print success
   - Print failed
   - Print paused

--- a/octoprint_wled/__init__.py
+++ b/octoprint_wled/__init__.py
@@ -141,6 +141,11 @@ class WLEDPlugin(
             }
         }
 
+    # Template plugin
+    def get_template_configs(self):
+        return [
+            {"type": "generic", "custom_bindings": True},
+        ]
 
 __plugin_name__ = "WLED Integration"
 __plugin_version__ = __version__

--- a/octoprint_wled/__init__.py
+++ b/octoprint_wled/__init__.py
@@ -57,6 +57,7 @@ class WLEDPlugin(
     # Event handling
     def on_event(self, event, payload):
         self.events.on_event(event, payload)
+        self.last_event = event
 
     # SettingsPlugin
     def get_settings_defaults(self) -> Dict[str, Any]:

--- a/octoprint_wled/__init__.py
+++ b/octoprint_wled/__init__.py
@@ -76,7 +76,6 @@ class WLEDPlugin(
                 "idle": {"enabled": True, "settings": []},
                 "disconnected": {"enabled": False, "settings": []},
                 "failed": {"enabled": False, "settings": []},
-                "started": {"enabled": False, "settings": []},
                 "success": {"enabled": False, "settings": []},
                 "paused": {"enabled": False, "settings": []},
                 # example settings entry, per segment

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -17,6 +17,7 @@ from octoprint_wled.wled.exceptions import (
 )
 
 CMD_TEST = "test"
+CMD_TOGGLE_FLASHLIGHT = "toggle_flashlight"
 
 
 class PluginAPI:
@@ -46,6 +47,18 @@ class PluginAPI:
                 self.test_wled, kwargs={"data": data}, name="WLED Test thread"
             )
             return flask.jsonify({"status": "started"})
+        if command = CMD_TOGGLE_FLASHLIGHT:
+            for (segmentIndex in range(self.plugin.wled.device.state.segments.count)):
+                self.plugin.wled.segment(
+                    segment_id=segmentIndex,
+                    brightness=255,
+                    color_primary=255, 255, 255,
+                    color_secondary=0, 0, 0,
+                    color_tertiary=0, 0, 0,
+                    effect="solid",
+                    intensity=255,
+                    on=True,
+                )
 
     def on_api_get(self, request):
         if self.get_thread and self.get_thread.is_alive():

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -52,9 +52,9 @@ class PluginAPI:
                 self.plugin.wled.segment(
                     segment_id=segmentIndex,
                     brightness=255,
-                    color_primary=255, 255, 255,
-                    color_secondary=0, 0, 0,
-                    color_tertiary=0, 0, 0,
+                    color_primary=(255, 255, 255),
+                    color_secondary=(0, 0, 0),
+                    color_tertiary=(0, 0, 0),
                     effect="solid",
                     intensity=255,
                     on=True,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -47,7 +47,7 @@ class PluginAPI:
                 self.test_wled, kwargs={"data": data}, name="WLED Test thread"
             )
             return flask.jsonify({"status": "started"})
-        if command = CMD_TOGGLE_FLASHLIGHT:
+        if command == CMD_TOGGLE_FLASHLIGHT:
             for (segmentIndex in range(self.plugin.wled.device.state.segments.count)):
                 self.plugin.wled.segment(
                     segment_id=segmentIndex,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -48,7 +48,7 @@ class PluginAPI:
             )
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
-            for (segmentIndex in range(self.plugin.wled.device.state.segments.count)):
+            for segmentIndex in range(self.plugin.wled.device.state.segments.count):
                 self.plugin.wled.segment(
                     segment_id=segmentIndex,
                     brightness=255,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -54,7 +54,8 @@ class PluginAPI:
         if command == CMD_TOGGLE_FLASHLIGHT:
             if self.flashlight_active:
                 self.plugin.events.on_event(self.plugin.events.last_event, None)
-                return
+                self.flashlight_active = False
+                return flask.jsonify({"on": False})
 
             for segmentIndex in range(len(self.plugin.wled.device.state.segments)):
                 self.plugin.wled.segment(
@@ -72,6 +73,8 @@ class PluginAPI:
                 on=True,
             )
             self.flashlight_active = True
+            return flask.jsonify({"on": True})
+            
 
     def on_api_get(self, request):
         if self.get_thread and self.get_thread.is_alive():

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -51,7 +51,7 @@ class PluginAPI:
             )
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
-            for segmentIndex in range(self.plugin.wled.device.state.segments.count()):
+            for segmentIndex in range(len(self.plugin.wled.device.state.segments)):
                 self.plugin.wled.segment(
                     segment_id=segmentIndex,
                     brightness=255,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -63,8 +63,8 @@ class PluginAPI:
                     on=True,
                 )
             self.plugin.wled.master(
-                brightness: 255,
-                on: True,
+                brightness=255,
+                on=True,
             )
 
     def on_api_get(self, request):

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -21,8 +21,6 @@ CMD_TOGGLE_FLASHLIGHT = "toggle_flashlight"
 
 
 class PluginAPI:
-    self flashlight_active = False
-
     def __init__(self, plugin):
         self.plugin = plugin  # type: octoprint_wled.WLEDPlugin
         # noinspection PyProtectedMember
@@ -36,6 +34,7 @@ class PluginAPI:
         # If this thread exists, then the response is 'in progress'
         self.get_thread: Optional[threading.Thread] = None
         self.post_test_thread: Optional[threading.Thread] = None
+        self.flashlight_active = False
 
     @staticmethod
     def get_api_commands() -> Dict[str, List[str]]:

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -62,6 +62,10 @@ class PluginAPI:
                     intensity=255,
                     on=True,
                 )
+            self.plugin.wled.master(
+                brightness: 255,
+                on: True,
+            )
 
     def on_api_get(self, request):
         if self.get_thread and self.get_thread.is_alive():

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -37,7 +37,10 @@ class PluginAPI:
 
     @staticmethod
     def get_api_commands() -> Dict[str, List[str]]:
-        return {CMD_TEST: ["config"]}
+        return {
+            CMD_TEST: ["config"],
+            CMD_TOGGLE_FLASHLIGHT: [],
+        }
 
     def on_api_command(self, command, data):
         if command == CMD_TEST:

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -71,6 +71,7 @@ class PluginAPI:
                 brightness=255,
                 on=True,
             )
+            self.flashlight_active = True
 
     def on_api_get(self, request):
         if self.get_thread and self.get_thread.is_alive():

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -52,7 +52,7 @@ class PluginAPI:
             )
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
-            if self.flashlight_active == True
+            if self.flashlight_active:
                 self.plugin.events.on_event(self.plugin.events.last_event)
                 return
 

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -55,7 +55,7 @@ class PluginAPI:
             if self.flashlight_active:
                 self.plugin.events.on_event(self.plugin.events.last_event, None)
                 self.flashlight_active = False
-                return flask.jsonify({"on": False})
+                return flask.jsonify({"flashlightIsActive": False})
 
             for segmentIndex in range(len(self.plugin.wled.device.state.segments)):
                 self.plugin.wled.segment(
@@ -73,12 +73,15 @@ class PluginAPI:
                 on=True,
             )
             self.flashlight_active = True
-            return flask.jsonify({"on": True})
+            return flask.jsonify({"flashlightIsActive": True})
             
 
     def on_api_get(self, request):
         if self.get_thread and self.get_thread.is_alive():
-            return flask.jsonify({"status": "in_progress"})
+            return flask.jsonify({
+                "status": "in_progress",
+                flashlightIsActive: self.flashlight_active,
+            })
 
         self.get_thread = util.start_thread(
             self.get_wled_status,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -52,7 +52,7 @@ class PluginAPI:
             )
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
-            if self.flashlight_active
+            if self.flashlight_active == True
                 self.plugin.events.on_event(self.plugin.events.last_event)
                 return
 

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -21,6 +21,8 @@ CMD_TOGGLE_FLASHLIGHT = "toggle_flashlight"
 
 
 class PluginAPI:
+    self flashlight_active = False
+
     def __init__(self, plugin):
         self.plugin = plugin  # type: octoprint_wled.WLEDPlugin
         # noinspection PyProtectedMember
@@ -51,6 +53,10 @@ class PluginAPI:
             )
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
+            if self.flashlight_active
+                self.plugin.events.on_event(self.plugin.events.last_event)
+                return
+
             for segmentIndex in range(len(self.plugin.wled.device.state.segments)):
                 self.plugin.wled.segment(
                     segment_id=segmentIndex,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -51,7 +51,7 @@ class PluginAPI:
             )
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
-            for segmentIndex in range(self.plugin.wled.device.state.segments.count):
+            for segmentIndex in range(self.plugin.wled.device.state.segments.count()):
                 self.plugin.wled.segment(
                     segment_id=segmentIndex,
                     brightness=255,

--- a/octoprint_wled/api.py
+++ b/octoprint_wled/api.py
@@ -53,7 +53,7 @@ class PluginAPI:
             return flask.jsonify({"status": "started"})
         if command == CMD_TOGGLE_FLASHLIGHT:
             if self.flashlight_active:
-                self.plugin.events.on_event(self.plugin.events.last_event)
+                self.plugin.events.on_event(self.plugin.events.last_event, None)
                 return
 
             for segmentIndex in range(len(self.plugin.wled.device.state.segments)):

--- a/octoprint_wled/events.py
+++ b/octoprint_wled/events.py
@@ -27,7 +27,6 @@ class PluginEventHandler:
         self.event_to_effect: Dict[str, str] = {
             Events.CONNECTED: "idle",
             Events.DISCONNECTED: "disconnected",
-            Events.PRINT_STARTED: "started",
             Events.PRINT_FAILED: "failed",
             Events.PRINT_DONE: "success",
             Events.PRINT_PAUSED: "paused"

--- a/octoprint_wled/events.py
+++ b/octoprint_wled/events.py
@@ -37,6 +37,7 @@ class PluginEventHandler:
 
     def on_event(self, event, payload) -> None:
         if event in self.event_to_effect.keys():
+            self.plugin.api.flashlight_active = False
             self.last_event = event
             start_thread(
                 self.update_effect, kwargs={"effect": self.event_to_effect[event]}

--- a/octoprint_wled/events.py
+++ b/octoprint_wled/events.py
@@ -29,7 +29,7 @@ class PluginEventHandler:
             Events.DISCONNECTED: "disconnected",
             Events.PRINT_FAILED: "failed",
             Events.PRINT_DONE: "success",
-            Events.PRINT_PAUSED: "paused"
+            Events.PRINT_PAUSED: "paused",
         }
 
         self.last_event: Optional[str] = None

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -286,6 +286,13 @@ $(function () {
                 }
             );
         };
+
+        self.toggle_flashlight = function () {
+            OctoPrint.simpleApiCommand(
+                "wled",
+                "toggle_flashlight"
+            ).done(update_light_status);
+        };
     }
     OCTOPRINT_VIEWMODELS.push({
         construct: WLEDViewModel,

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -5,7 +5,7 @@
  * License: AGPLv3
  */
 $(function () {
-    function WLEDViewModel(parameters) {
+    function WLEDSettingsViewModel(parameters) {
         console.log(OctoPrint);
         const self = this;
 
@@ -289,7 +289,7 @@ $(function () {
         };
     }
     OCTOPRINT_VIEWMODELS.push({
-        construct: WLEDViewModel,
+        construct: WLEDSettingsViewModel,
         dependencies: ["settingsViewModel"],
         elements: ["#settings_plugin_wled"],
     });
@@ -298,11 +298,9 @@ $(function () {
 
 $(function () {
     function WLEDNavbarViewModel(parameters) {
-        console.log(OctoPrint);
         const self = this;
 
         self.toggleFlashlight = function () {
-            console.log('Toggle Flashlight');
             OctoPrint.simpleApiCommand(
                 "wled",
                 "toggle_flashlight"

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -7,7 +7,7 @@
 $(function () {
     function WLEDViewModel(parameters) {
         console.log(OctoPrint);
-        var self = this;
+        const self = this;
 
         self.allEventNames = ["idle", "disconnected", "started", "failed", "success", "paused"]
 
@@ -287,17 +287,33 @@ $(function () {
                 }
             );
         };
-
-        self.toggleFlashlight = function () {
-            OctoPrint.simpleApiCommand(
-                "wled",
-                "toggle_flashlight"
-            ).done(update_light_status);
-        };
     }
     OCTOPRINT_VIEWMODELS.push({
         construct: WLEDViewModel,
         dependencies: ["settingsViewModel"],
         elements: ["#settings_plugin_wled"],
+    });
+});
+
+
+$(function () {
+    function WLEDNavbarViewModel(parameters) {
+        console.log(OctoPrint);
+        const self = this;
+
+        self.toggleFlashlight = function () {
+            console.log('Toggle Flashlight');
+            OctoPrint.simpleApiCommand(
+                "wled",
+                "toggle_flashlight"
+            );
+        };
+    }
+
+
+    OCTOPRINT_VIEWMODELS.push({
+        construct: WLEDNavbarViewModel,
+        dependencies: [],
+        elements: ["#wled_navbar"],
     });
 });

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -4,6 +4,9 @@
  * Author: Charlie Powell
  * License: AGPLv3
  */
+
+const ko = window.ko;
+
 $(function () {
     function WLEDSettingsViewModel(parameters) {
         console.log(OctoPrint);
@@ -300,11 +303,18 @@ $(function () {
     function WLEDNavbarViewModel(parameters) {
         const self = this;
 
+        self.flashlightIsOn = ko.observable(false);
+
+        self.updateFlashlightStatus = function (response) {
+            self.flashlightIsOn(on);
+        }
+
         self.toggleFlashlight = function () {
             OctoPrint.simpleApiCommand(
                 "wled",
                 "toggle_flashlight"
-            );
+            ).done(updateFlashlightStatus)
+            self.updateFlashlightStatus();
         };
     }
 

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -303,10 +303,10 @@ $(function () {
     function WLEDNavbarViewModel(parameters) {
         const self = this;
 
-        self.flashlightIsOn = ko.observable(false);
+        self.flashlightIsActive = ko.observable(false);
 
         self.updateFlashlightStatus = function (response) {
-            self.flashlightIsOn(response.flashlightIsActive);
+            self.flashlightIsActive(response.flashlightIsActive);
         }
 
         self.toggleFlashlight = function () {

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -313,7 +313,7 @@ $(function () {
             OctoPrint.simpleApiCommand(
                 "wled",
                 "toggle_flashlight"
-            ).done(updateFlashlightStatus)
+            ).done(self.updateFlashlightStatus)
             self.updateFlashlightStatus();
         };
     }

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -6,7 +6,7 @@
  */
 $(function () {
     function WLEDViewModel(parameters) {
-        console.log(this);
+        console.log(OctoPrint);
         var self = this;
 
         self.allEventNames = ["idle", "disconnected", "started", "failed", "success", "paused"]

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -313,11 +313,13 @@ $(function () {
             OctoPrint.simpleApiCommand(
                 "wled",
                 "toggle_flashlight"
-            ).done(self.updateFlashlightStatus)
-            self.updateFlashlightStatus();
+            ).done(self.updateFlashlightStatus);
+        };
+
+        self.onBeforeBinding = function () {
+            OctoPrint.simpleApiGet("wled").done(self.updateFlashlightStatus);
         };
     }
-
 
     OCTOPRINT_VIEWMODELS.push({
         construct: WLEDNavbarViewModel,

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -6,6 +6,7 @@
  */
 $(function () {
     function WLEDViewModel(parameters) {
+        console.log(this);
         var self = this;
 
         self.allEventNames = ["idle", "disconnected", "started", "failed", "success", "paused"]
@@ -287,7 +288,7 @@ $(function () {
             );
         };
 
-        self.toggle_flashlight = function () {
+        self.toggleFlashlight = function () {
             OctoPrint.simpleApiCommand(
                 "wled",
                 "toggle_flashlight"

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -306,7 +306,7 @@ $(function () {
         self.flashlightIsOn = ko.observable(false);
 
         self.updateFlashlightStatus = function (response) {
-            self.flashlightIsOn(on);
+            self.flashlightIsOn(response.flashlightIsActive);
         }
 
         self.toggleFlashlight = function () {

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -1,0 +1,7 @@
+<a class="pull-right"
+   style="float: left; font-size:20px"
+   href="javascript:void(0)"
+   data-bind="click: toggle_flashlight"
+>
+    <i class="fa-custom-lightbulb"></i>
+</a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -4,8 +4,11 @@
    href="javascript:void(0)"
    data-bind="click: toggleFlashlight"
 >
-    <!-- filled bulb -->
-    <i class="fas fa-lightbulb" data-bind="css: {display: flashlightIsActive ? '' : 'none'}"></i>
-    <!-- Outlined bulb -->
-    <i class="far fa-lightbulb" data-bind="css: {display: flashlightIsActive ? 'none' : ''}"></i>
+    {% if flashlightIsActive %}
+        <!-- filled bulb -->
+        <i class="fas fa-lightbulb"></i>
+    {% else %}
+        <!-- Outlined bulb -->
+        <i class="far fa-lightbulb"></i>
+    {% endif %}
 </a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -5,7 +5,7 @@
    data-bind="click: toggleFlashlight"
 >
     <!-- filled bulb -->
-    <i class="fas fa-lightbulb" data-bind="visible: flashlightIsOn"></i>
+    <i class="fas fa-lightbulb" data-bind="visible: flashlightIsActive()"></i>
     <!-- Outlined bulb -->
-    <i class="far fa-lightbulb" data-bind="visible: !flashlightIsOn"></i>
+    <i class="far fa-lightbulb" data-bind="visible: !flashlightIsActive()"></i>
 </a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -3,5 +3,5 @@
    href="javascript:void(0)"
    data-bind="click: toggleFlashlight"
 >
-    <i class="fa-custom-lightbulb"></i>
+    <i class="fas fa-lightbulb"></i>
 </a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -4,11 +4,9 @@
    href="javascript:void(0)"
    data-bind="click: toggleFlashlight"
 >
-    {% if flashlightIsActive %}
-        <!-- filled bulb -->
-        <i class="fas fa-lightbulb"></i>
-    {% else %}
-        <!-- Outlined bulb -->
-        <i class="far fa-lightbulb"></i>
-    {% endif %}
+    <!-- filled bulb -->
+    <i class="fas fa-lightbulb" data-bind="visible: flashlightIsActive"></i>
+
+    <!-- Outlined bulb -->
+    <i class="far fa-lightbulb" data-bind="hidden: flashlightIsActive"></i>
 </a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -5,7 +5,7 @@
    data-bind="click: toggleFlashlight"
 >
     <!-- filled bulb -->
-    <i class="fas fa-lightbulb" data-bind="visible: flashlightIsActive()"></i>
+    <i class="fas fa-lightbulb" data-bind="css: {display: flashlightIsActive ? '' : 'none'}"></i>
     <!-- Outlined bulb -->
-    <i class="far fa-lightbulb" data-bind="visible: !flashlightIsActive()"></i>
+    <i class="far fa-lightbulb" data-bind="css: {display: flashlightIsActive ? 'none' : ''}"></i>
 </a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -4,5 +4,8 @@
    href="javascript:void(0)"
    data-bind="click: toggleFlashlight"
 >
-    <i class="fas fa-lightbulb"></i>
+    <!-- filled bulb -->
+    <i class="fas fa-lightbulb" data-bind="visible: flashlightIsOn"></i>
+    <!-- Outlined bulb -->
+    <i class="far fa-lightbulb" data-bind="visible: !flashlightIsOn"></i>
 </a>

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -1,4 +1,5 @@
 <a class="pull-right"
+   id="wled_navbar"
    style="float: left; font-size:20px"
    href="javascript:void(0)"
    data-bind="click: toggleFlashlight"

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -1,7 +1,7 @@
 <a class="pull-right"
    style="float: left; font-size:20px"
    href="javascript:void(0)"
-   data-bind="click: toggle_flashlight"
+   data-bind="click: toggleFlashlight"
 >
     <i class="fa-custom-lightbulb"></i>
 </a>


### PR DESCRIPTION
this PR implements the "Flashlight" feature.

You will get a Lighbulb Icon/Button in the Octoprint Navbar which turns the LEDS White (255 Brightness) and On.
If pressed again it restores the last effect.

Also: if in the meantime an event is triggered by octoprint (e.g. successfull print) this will overwrite the flashlight and show the effect for that event.

Also2: the icon reflects the current flash-light status. Filled Bulb = On, Outlined Bulb = Off