### PR TITLE
feat: flashlight button

### DIFF
--- a/octoprint_wled/__init__.py
+++ b/octoprint_wled/__init__.py
@@ -57,6 +57,7 @@ class WLEDPlugin(
     # Event handling
     def on_event(self, event, payload):
         self.events.on_event(event, payload)
+        self.last_event = event
 
     # SettingsPlugin
     def get_settings_defaults(self) -> Dict[str, Any]:
@@ -140,6 +141,11 @@ class WLEDPlugin(
             }
         }
 
+    # Template plugin
+    def get_template_configs(self):
+        return [
+            {"type": "generic", "custom_bindings": True},
+        ]
 
 __plugin_name__ = "WLED Integration"
 __plugin_version__ = __version__

--- a/octoprint_wled/events.py
+++ b/octoprint_wled/events.py
@@ -36,6 +36,7 @@ class PluginEventHandler:
 
     def on_event(self, event, payload) -> None:
         if event in self.event_to_effect.keys():
+            self.plugin.api.flashlight_active = False
             self.last_event = event
             start_thread(
                 self.update_effect, kwargs={"effect": self.event_to_effect[event]}

--- a/octoprint_wled/static/js/wled.js
+++ b/octoprint_wled/static/js/wled.js
@@ -4,9 +4,12 @@
  * Author: Charlie Powell
  * License: AGPLv3
  */
+
+const ko = window.ko;
+
 $(function () {
-    function WLEDViewModel(parameters) {
-        var self = this;
+    function WLEDSettingsViewModel(parameters) {
+        const self = this;
 
         self.settingsViewModel = parameters[0];
 
@@ -315,8 +318,38 @@ $(function () {
         };
     }
     OCTOPRINT_VIEWMODELS.push({
-        construct: WLEDViewModel,
+        construct: WLEDSettingsViewModel,
         dependencies: ["settingsViewModel"],
         elements: ["#settings_plugin_wled"],
+    });
+});
+
+
+$(function () {
+    function WLEDNavbarViewModel(parameters) {
+        const self = this;
+
+        self.flashlightIsActive = ko.observable(false);
+
+        self.updateFlashlightStatus = function (response) {
+            self.flashlightIsActive(response.flashlightIsActive);
+        }
+
+        self.toggleFlashlight = function () {
+            OctoPrint.simpleApiCommand(
+                "wled",
+                "toggle_flashlight"
+            ).done(self.updateFlashlightStatus);
+        };
+
+        self.onBeforeBinding = function () {
+            OctoPrint.simpleApiGet("wled").done(self.updateFlashlightStatus);
+        };
+    }
+
+    OCTOPRINT_VIEWMODELS.push({
+        construct: WLEDNavbarViewModel,
+        dependencies: [],
+        elements: ["#wled_navbar"],
     });
 });

--- a/octoprint_wled/templates/wled_navbar.jinja2
+++ b/octoprint_wled/templates/wled_navbar.jinja2
@@ -1,0 +1,12 @@
+<a class="pull-right"
+   id="wled_navbar"
+   style="float: left; font-size:20px"
+   href="javascript:void(0)"
+   data-bind="click: toggleFlashlight"
+>
+    <!-- filled bulb -->
+    <i class="fas fa-lightbulb" data-bind="visible: flashlightIsActive"></i>
+
+    <!-- Outlined bulb -->
+    <i class="far fa-lightbulb" data-bind="hidden: flashlightIsActive"></i>
+</a>


### PR DESCRIPTION
this PR implements the "Flashlight" feature.

You will get a Lighbulb Icon/Button in the Octoprint Navbar which turns the LEDS White (255 Brightness) and On.
If pressed again it restores the last effect.

Also: if in the meantime an event is triggered by octoprint (e.g. successfull print) this will overwrite the flashlight and show the effect for that event.

Also2: the icon reflects the current flash-light status. Filled Bulb = On, Outlined Bulb = Off